### PR TITLE
Added and rendered a socal portion of bathymetry layer

### DIFF
--- a/src/js/config.js
+++ b/src/js/config.js
@@ -1,5 +1,7 @@
 const kelpProductivityLayerUrl =
-  "https://services7.arcgis.com/4c8njmg1eMIbzYXM/arcgis/rest/services/ussw11999_maxcanopy/FeatureServer/0";
+  "https://services7.arcgis.com/4c8njmg1eMIbzYXM/arcgis/rest/services/l2scb_maxcanopy/FeatureServer/0";
+const bathymetryLayerUrl = 
+"https://services7.arcgis.com/4c8njmg1eMIbzYXM/arcgis/rest/services/Join_Features_to_l2scb_maxcanopy/FeatureServer/0";
 const shippingLanesLayerUrl =
   "https://services7.arcgis.com/4c8njmg1eMIbzYXM/arcgis/rest/services/ShippingLanes_SCA/FeatureServer/1";
 const dangerZonesAndRestrictedAreasLayerUrl =
@@ -16,6 +18,7 @@ const locatorTaskUrl =
 
 export {
   kelpProductivityLayerUrl,
+  bathymetryLayerUrl,
   shippingLanesLayerUrl,
   dangerZonesAndRestrictedAreasLayerUrl,
   mpaInventoryLayerUrl,

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,5 +1,6 @@
 import {
   kelpProductivityLayerUrl,
+  bathymetryLayerUrl,
   shippingLanesLayerUrl,
   dangerZonesAndRestrictedAreasLayerUrl,
   mpaInventoryLayerUrl,
@@ -9,6 +10,7 @@ import {
 } from "./config.js";
 import {
   kelpProductivityPopupTemplate,
+  bathymetryPopupTemplate,
   federalAndStateWatersPopupTemplate,
   shippingLanesPopupTemplate,
   dangerZonesAndRestrictedAreasPopupTemplate,
@@ -18,6 +20,7 @@ import {
 import {
   referenceScale,
   kelpProductivityRenderer,
+  bathymetryRenderer,
   dangerZonesAndRestrictedAreasRenderer,
 } from "./renderer.js";
 
@@ -61,14 +64,13 @@ require([
     popupTemplate: kelpProductivityPopupTemplate,
   });
 
-  // // Bathymetry layer
-  // const bathymetryLayer = new FeatureLayer({
-  //   url:
-  //     "https://services7.arcgis.com/4c8njmg1eMIbzYXM/arcgis/rest/services/l2scb_bathymetry/FeatureServer/0",
-  //   visible: false,
-  //   renderer: bathymetryRenderer,
-  //   popupTemplate: bathymetryPopupTemplate,
-  // });
+  // Bathymetry layer
+  const bathymetryLayer = new FeatureLayer({
+    url: bathymetryLayerUrl,
+    visible: false,
+    renderer: bathymetryRenderer,
+    popupTemplate: bathymetryPopupTemplate,
+  });
 
   // Shipping lanes layer
   const shippingLanesLayer = new FeatureLayer({
@@ -124,7 +126,7 @@ require([
     },
     layers: [
       kelpProductivityLayer,
-      // bathymetryLayer,
+      bathymetryLayer,
       shippingLanesLayer,
       dangerZonesAndRestrictedAreasLayer,
       mpaInventoryLayer,
@@ -134,7 +136,7 @@ require([
   });
 
   // Reorder layers - sink federal and state waters and bathymetry layers to the bottom
-  // webmap.layers.reorder(bathymetryLayer, 0);
+  webmap.layers.reorder(bathymetryLayer, 0);
   webmap.layers.reorder(federalAndStateWatersLayer, 1);
   webmap.layers.reorder(kelpProductivityLayer, 2);
   webmap.layers.reorder(mpaInventoryLayer, 3);
@@ -142,11 +144,15 @@ require([
   webmap.layers.reorder(shippingLanesLayer, 5);
   webmap.layers.reorder(principalPortsLayer, 6);
 
+  // Set minimum scale 
+  kelpProductivityLayer.minScale = 0; 
+  bathymetryLayer.minScale = 0;
+
   const view = new MapView({
     container: "viewDiv",
     map: webmap,
     center: [-118.805, 34.027], // longitude, latitude
-    zoom: 9,
+    zoom: 7,
     scale: referenceScale * 4,
   });
 
@@ -161,11 +167,11 @@ require([
     kelpProductivityLayer.visible = kelpProductivityLayerToggle.checked;
   });
 
-  // // Toggle function of bathymetry layer
-  // const bathymetryLayerToggle = document.getElementById("bathymetryLayer");
-  // bathymetryLayerToggle.addEventListener("change", function () {
-  //   bathymetryLayer.visible = bathymetryLayerToggle.checked;
-  // });
+  // Toggle function of bathymetry layer
+  const bathymetryLayerToggle = document.getElementById("bathymetryLayer");
+  bathymetryLayerToggle.addEventListener("change", function () {
+    bathymetryLayer.visible = bathymetryLayerToggle.checked;
+  });
 
   // Toggle function of shipping lanes layer
   const shippingLanesLayerToggle = document.getElementById(
@@ -223,10 +229,10 @@ require([
             layer: kelpProductivityLayer,
             title: "Kelp Productivity (Biomass in kilogram-dry)",
           },
-          // {
-          //   layer: bathymetryLayer,
-          //   title: "Bathymetry (Depth in meters)",
-          // },
+          {
+            layer: bathymetryLayer,
+            title: "Bathymetry (Depth in meters)",
+          },
           {
             layer: shippingLanesLayer,
             title: "Shipping Lanes",

--- a/src/js/popup_template.js
+++ b/src/js/popup_template.js
@@ -15,22 +15,22 @@ var kelpProductivityPopupTemplate = {
   ],
 };
 
-// // Popup template for bathymetry layer
-// var bathymetryPopupTemplate = {
-//   //autocasts as new PopupTemplate()
-//   title: "Bathymetry",
-//   content: [
-//     {
-//       type: "fields",
-//       fieldInfos: [
-//         {
-//           fieldName: "depth",
-//           label: "Depth (meters)",
-//         },
-//       ],
-//     },
-//   ],
-// };
+// Popup template for bathymetry layer
+var bathymetryPopupTemplate = {
+  //autocasts as new PopupTemplate()
+  title: "Bathymetry",
+  content: [
+    {
+      type: "fields",
+      fieldInfos: [
+        {
+          fieldName: "depth",
+          label: "Depth (meters)",
+        },
+      ],
+    },
+  ],
+};
 
 // Popup template for shipping lanes layer
 var shippingLanesPopupTemplate = {
@@ -131,6 +131,7 @@ var federalAndStateWatersPopupTemplate = {
 
 export {
   kelpProductivityPopupTemplate,
+  bathymetryPopupTemplate,
   shippingLanesPopupTemplate,
   dangerZonesAndRestrictedAreasPopupTemplate,
   mpaInventoryPopupTeamplate,

--- a/src/js/renderer.js
+++ b/src/js/renderer.js
@@ -5,8 +5,7 @@ const kelpProductivityRenderer = {
   type: "simple", // autocasts as new SimpleRenderer()
   symbol: {
     type: "simple-marker",
-    size: 10,
-    // color: "black",
+    size: 5,
     outline: {
       width: 0,
       color: "white",
@@ -27,32 +26,33 @@ const kelpProductivityRenderer = {
   ],
 };
 
-// // Display bathymetry with simple renderer
-// const bathymetryRenderer = {
-//   type: "simple",
-//   symbol: {
-//     type: "simple-marker",
-//     size: 6,
-//     color: "black",
-//     outline: {
-//       width: 0,
-//       color: "white",
-//     },
-//   },
-//   visualVariables: [
-//     {
-//       type: "color",
-//       field: "depth",
-//       stops: [
-//         { value: 0, color: "#F5FFD7", opacity: 0.2 },
-//         { value: 1000, color: "#83B5BC", opacity: 0.2 },
-//         { value: 2000, color: "#5D9CB3", opacity: 0.2 },
-//         { value: 3000, color: "#3783AA", opacity: 0.2 },
-//         { value: 4000, color: "#126BA2", opacity: 0.2 },
-//       ],
-//     },
-//   ],
-// };
+// Display bathymetry with simple renderer
+const bathymetryRenderer = {
+  type: "simple",
+  symbol: {
+    type: "simple-marker",
+    size: 6,
+    outline: {
+      width: 0,
+      color: "white",
+    },
+  },
+  visualVariables: [
+    {
+      type: "color",
+      field: "depth",
+      stops: [
+        { value: 0, color: "#FDFD5A", opacity: 0.2 },
+        { value: 250, color: "#27DF87", opacity: 0.2 },
+        { value: 500, color: "#1382C3", opacity: 0.2 },
+        { value: 1000, color: "#0025FF", opacity: 0.2 },
+        { value: 2000, color: "#0F21E0", opacity: 0.2 },
+        { value: 3000, color: "#1E1DC2", opacity: 0.2 },
+        { value: 4000, color: "#2E1AA4", opacity: 0.2 },
+      ],
+    },
+  ],
+};
 
 // Display danger zones and restricted areas with simple renderer
 
@@ -110,5 +110,6 @@ const dangerZonesAndRestrictedAreasRenderer = {
 export {
   referenceScale,
   kelpProductivityRenderer,
+  bathymetryRenderer,
   dangerZonesAndRestrictedAreasRenderer,
 };


### PR DESCRIPTION
- Added a "masked" bathymetry layer by performing a one-to-one data join using the kelp productivity layer as a target (I'm adding this just as a place holder until Christina gets back to me with updates on what to do with the large bathymetry shp file).
- Rendered data layer using bathymetry color ramp 
- Replaced kelp productivity data layer URL
<img width="1222" alt="Screen Shot 2020-11-06 at 8 38 17 PM" src="https://user-images.githubusercontent.com/41706004/98432174-7bc70a80-2070-11eb-81f4-cd8f8ff452c0.png">
