### PR TITLE
query, normalize, and render data onto the map -- feature 2

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -130,6 +130,8 @@ require([
     url: locatorTaskUrl,
   });
 
+  const resultsLayer = new GraphicsLayer();
+
   const webmap = new WebMap({
     portalItem: {
       id: "ab809d7d499b4ba9b7c87dbdefc4bbf7",
@@ -142,6 +144,7 @@ require([
       mpaInventoryLayer,
       principalPortsLayer,
       federalAndStateWatersLayer,
+      resultsLayer,
     ],
   });
 
@@ -153,6 +156,7 @@ require([
   webmap.layers.reorder(dangerZonesAndRestrictedAreasLayer, 4);
   webmap.layers.reorder(shippingLanesLayer, 5);
   webmap.layers.reorder(principalPortsLayer, 6);
+  webmap.layers.reorder(resultsLayer, 7);
 
   // Set minimum scale
   kelpProductivityLayer.minScale = 0;
@@ -489,6 +493,55 @@ require([
       labels: true,
       rangeLabels: true,
     },
+  });
+
+  const querySFI = document.getElementById("query-sfi");
+
+  querySFI.addEventListener("click", function () {
+    resultsLayer.removeAll();
+    const querySizeLimit = 5000;
+    for (let i = 1; i < 320000; i += querySizeLimit) {
+      queryData(i, querySizeLimit).then(displayResults);
+    }
+
+    function queryData(index, querySizeLimit) {
+      const query = kelpProductivityLayer.createQuery();
+      query.start = index;
+      query.num = querySizeLimit;
+      return kelpProductivityLayer.queryFeatures(query);
+    }
+    function displayResults(results) {
+      const maxProductivity = getMaxBiomassValues(results.features);
+      const features = results.features.map(function (graphic) {
+        let newBiomass = graphic.attributes.biomass / maxProductivity;
+        graphic.attributes = {
+          biomass: newBiomass.toFixed(6),
+        };
+        graphic.symbol = {
+          type: "simple-marker", // autocasts as new SimpleMarkerSymbol()
+          size: 1,
+          color: "green",
+        };
+        return graphic;
+      });
+      resultsLayer.addMany(features);
+
+      function getMaxBiomassValues(features) {
+        var maxValue = 0;
+        features.map(function (feature) {
+          if (feature.attributes.biomass > maxValue)
+            maxValue = feature.attributes.biomass;
+        });
+        return maxValue;
+      }
+    }
+  });
+
+  const clearSFI = document.getElementById("clear-report");
+  clearSFI.addEventListener("click", function () {
+    view.when(function () {
+      resultsLayer.removeAll();
+    });
   });
 
   // TODO: ADD 7 Layers


### PR DESCRIPTION
Implementation of step 0 and 1 of `Calculate SFI Feature`

* Added new result layer for `SFI` result layer, which should be shown after users click `calculate SFI` button

* Test the uploaded data successfully by querying from browser/client-side

* Access kelp biomass layer (B; units are kg-dry/m2). And normalize as the ratio of biomass (B) at each point to the maximum biomass value observed for that layer. The resulting values should be between zero and one.

![image](https://user-images.githubusercontent.com/28212783/99026402-bc66ce00-251f-11eb-8342-9948d32adc3d.png)


Notes:
* `maxRecordCount` is a hard limit of the query size which is a read-only attribute of the `FeatureLayer`. 
    *  A value of too low will cause `server connection timeout`
    * A value of too hight will cause a high rendering time for data layers
    * A well-balanced trade-off might be needed in future

* `GraphicLayer.addMany()` is so slow that it takes a minute to render 317960 data points onto the map whereas the query process only takes a few seconds.

* Thread killing of another `event listener` might be needed if the long rendering time issue will not be solved in future.
