### PR TITLE
Minor Change to Display Mode of Geometry Query UI

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -351,6 +351,7 @@ require([
     function addGeometryQueryWidget() {
       // widget #5: Geometry Query
       window.view = view;
+      view.ui.add([queryDiv], "bottom-left");
     }
 
     function addDistanceMeasurementWidget() {
@@ -537,11 +538,6 @@ require([
     // add a GraphicsLayer for the sketches and the buffer
     const sketchLayer = new GraphicsLayer();
     view.map.addMany([sketchLayer]);
-
-    webmap.load().then(function () {
-      queryDiv.style.display = "block";
-    });
-    view.ui.add([queryDiv], "bottom-left");
 
     // use SketchViewModel to draw polygons that are used as a query
     let sketchGeometry = null;

--- a/src/js/nav.js
+++ b/src/js/nav.js
@@ -14,7 +14,7 @@ function navButton(selectedButton) {
 function toggle(selectedButton) {
   const layerToggle = document.getElementById("layerToggle"); //layerToggle is the id of widget
   const sfiCalc = document.getElementById("sfiCalc"); // TODO: Need to implement feature and name widget id to sfiCalc
-  const reportSfi = document.getElementById("reportSfi"); // TODO: Need to implement feature and name widget id to reportSfi
+  const reportSfi = document.getElementById("queryDiv"); // queryDiv is the id of widget
   switch (selectedButton) {
     case "layer-toggle":
       layerToggle.style.display = reverseDisplayStatus(


### PR DESCRIPTION
- Set the default display mode of Geometry Query UI to "none"
- Added display control of Geometry Query UI with the corresponding nav button.

Now layer toggle, SFI calculation, and report of SFI are all controlled by nav buttons. Todo: arrange the location for the summary report UI

**When the map view is initially loaded:**
![image](https://user-images.githubusercontent.com/58122003/99136043-e6260f00-265d-11eb-9f07-40157d0f1b77.png)

**When the nav button is clicked**
![image](https://user-images.githubusercontent.com/58122003/99136073-035add80-265e-11eb-9b15-2f6b64d6a643.png)
![image](https://user-images.githubusercontent.com/58122003/99136077-081f9180-265e-11eb-90c1-f43b599e0dc2.png)
