### PR TITLE
Implemented area measurement and histogram for report of SFI

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -186,7 +186,14 @@
             <span>The average value of the selected area is</span>
             <div id="sfiOutput"></div>
             <span>Histogram of Seaweed Farming Index (SFI)</span>
-            <div id="sfiHistogram">Histogram Here</div>
+            <div id="sfiHistogram">
+              <div id="histogramTitle">Histogram Here</div>
+              <div id="histogram"></div>
+              <div class="labels">
+                <span style="float: left" id="minSFILabelText"></span>
+                <span style="float: right" id="maxSFILabelText"></span>
+              </div>
+            </div>
           </div>
         </div>
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -25,9 +25,13 @@ require([
   "esri/layers/FeatureLayer",
   "esri/layers/GraphicsLayer",
   "esri/Graphic",
+  "esri/geometry/Polygon",
   "esri/geometry/geometryEngine",
-  "esri/core/promiseUtils",
   "esri/geometry/support/geodesicUtils",
+  "esri/core/promiseUtils",
+  "esri/core/watchUtils",
+  "esri/smartMapping/statistics/histogram",
+  "esri/smartMapping/statistics/summaryStatistics",
   //"esri/units",
   // widgets
   "esri/widgets/Legend",
@@ -39,7 +43,7 @@ require([
   "esri/widgets/DistanceMeasurement2D",
   "esri/widgets/AreaMeasurement2D",
   "esri/widgets/Sketch/SketchViewModel",
-  "esri/core/watchUtils",
+  "esri/widgets/Histogram",
 ], function (
   // mapping
   WebMap,
@@ -47,9 +51,13 @@ require([
   FeatureLayer,
   GraphicsLayer,
   Graphic,
+  Polygon,
   geometryEngine,
-  promiseUtils,
   geodesicUtils,
+  promiseUtils,
+  watchUtils,
+  histogram,
+  summaryStatistics,
   //Units,
   // widgets
   Legend,
@@ -61,7 +69,7 @@ require([
   DistanceMeasurement2D,
   AreaMeasurement2D,
   SketchViewModel,
-  watchUtils
+  Histogram
 ) {
   /****************************************************
    * Declaration zone for data layers
@@ -327,23 +335,21 @@ require([
       });
 
       // Handle Legend Widget
-      legendHandle = watchUtils.pausable(
-        legendExpand,
-        "expanded",
-        function (newValue) {
-          if (newValue === true) {
-            legendHandle.pause();
-            setTimeout(function () {
-              bookmarkHandle.resume();
-            }, 100);
-          } else {
-            legendHandle.resume();
-          }
-          if (bookmarkExpand.expanded) {
-            bookmarkExpand.collapse();
-          }
+      legendHandle = watchUtils.pausable(legendExpand, "expanded", function (
+        newValue
+      ) {
+        if (newValue === true) {
+          legendHandle.pause();
+          setTimeout(function () {
+            bookmarkHandle.resume();
+          }, 100);
+        } else {
+          legendHandle.resume();
         }
-      );
+        if (bookmarkExpand.expanded) {
+          bookmarkExpand.collapse();
+        }
+      });
 
       // Handle Bookmarks Widget
       bookmarkHandle = watchUtils.pausable(
@@ -924,6 +930,7 @@ require([
       sketchViewModel.on("create", function (event) {
         if (event.state === "complete") {
           sketchGeometry = event.graphic.geometry;
+          console.log(sketchGeometry);
           runQuery();
           view.ui.move(queryDiv, "bottom-right");
           view.ui.move(coordsWidget, "bottom-right");
@@ -977,8 +984,7 @@ require([
           querySFIAndCreateHistogram(),
           queryDistanceToPort(),
           queryBathymetry(),
-          calculatePolygonArea(),
-          queryJurisdiction(),
+          areaMeasurementAndQueryJurisdiction(),
         ]);
       });
 
@@ -1066,6 +1072,23 @@ require([
             Math.round((stats.avgSFI + Number.EPSILON) * 100000000) / 100000000;
         }
 
+        function fetchStats(layer, field) {
+          const params = {
+            layer: layer,
+            field: field,
+            numBins: 200,
+          };
+
+          return promiseUtils.eachAlways([
+            histogram(params),
+            summaryStatistics(params),
+          ]);
+        }
+
+        function formatToDegrees(value) {
+          return Math.round((value + Number.EPSILON) * 100000000) / 100000000;
+        }
+
         function createHistogram(featureLayer, sfiFieldName) {
           var sfiHistogramArray = [];
 
@@ -1103,8 +1126,37 @@ require([
               source: sfiHistogramArray,
             });
 
-            console.log(sfiHistogramLayer);
             // Todo: Histogram Implementation Logic here
+            fetchStats(sfiHistogramLayer, "SFI")
+              .then(function (response) {
+                console.log(response);
+                const histogramResult = response[0].value;
+                console.log(histogramResult);
+                const statsResult = response[1].value;
+                console.log(statsResult);
+
+                const minElement = document.getElementById("minSFILabelText");
+                const maxElement = document.getElementById("maxSFILabelText");
+                minElement.innerText = formatToDegrees(
+                  histogramResult.minValue
+                );
+                maxElement.innerText = formatToDegrees(
+                  histogramResult.maxValue
+                );
+
+                // Creates a Histogram instance from the returned histogram result
+                const histogramWidget = Histogram.fromHistogramResult(
+                  histogramResult
+                );
+                histogramWidget.container = "histogram";
+                histogramWidget.average = statsResult.avg;
+                histogramWidget.labelFormatFunction = function (value, type) {
+                  return formatToDegrees(value);
+                };
+              })
+              .catch(function (error) {
+                console.error(error);
+              });
           });
         }
       }
@@ -1164,11 +1216,15 @@ require([
         bathymetryLayer.queryFeatures(query).then(function (response) {
           var stats = response.features[0].attributes;
 
-          var minDepthText = document.getElementById("minDepth");
-          var avgDepthText = document.getElementById("avgDepth");
-          var maxDepthText = document.getElementById("maxDepth");
-          var minDepthAvailable = document.getElementById("minDepthAvailable");
-          var maxDepthAvailable = document.getElementById("maxDepthAvailable");
+          const minDepthText = document.getElementById("minDepth");
+          const avgDepthText = document.getElementById("avgDepth");
+          const maxDepthText = document.getElementById("maxDepth");
+          const minDepthAvailable = document.getElementById(
+            "minDepthAvailable"
+          );
+          const maxDepthAvailable = document.getElementById(
+            "maxDepthAvailable"
+          );
 
           minDepthText.innerHTML = -1 * stats.minDepth;
           avgDepthText.innerHTML =
@@ -1179,16 +1235,27 @@ require([
         });
       }
 
-      function calculatePolygonArea() {
-        //const areas = geodesicUtils.geodesicAreas(
-        //  [sketchGeometry],
-        //  "square-kilometers"
-        //);
-      }
-
       var jurisdictionChart = null;
 
-      function queryJurisdiction() {
+      function areaMeasurementAndQueryJurisdiction() {
+        const polygonProperties = {
+          hasM: false,
+          hasZ: false,
+          rings: sketchGeometry.rings,
+        };
+        const sketchPolygon = new Polygon(polygonProperties);
+        console.log(sketchPolygon);
+
+        const areas = geodesicUtils.geodesicAreas(
+          [sketchPolygon],
+          "square-kilometers"
+        );
+        console.log(areas);
+        const area = Math.round((areas[0] + Number.EPSILON) * 100) / 100;
+        console.log(area);
+        const areaText = document.getElementById("reportAreaOut");
+        areaText.innerHTML = area + " km<sup>2</sup>";
+
         const statDefinitions = [
           {
             onStatisticField:


### PR DESCRIPTION
- Created a polygon object with rings provided by the sketch model view
- Got the polygon’s area value using geodesicUtils 
- Displayed the value in the summary report
- Added code for histogram (To be discussed & improved)

Area measurement
Issue: In the [code example](https://developers.arcgis.com/javascript/latest/api-reference/esri-geometry-support-geodesicUtils.html#geodesicAreas), accurate latitude and longitude of each geographical point in a polygon are needed to calculate the area. The rings provided by the sketch view model are not geographical coordinates, which causes a big deviation of the area value. I am not sure what those big numbers mean. I'm pretty sure there's no logical mistake in the implementation itself.

Todo: Figure out why rings provided by the sketch view model are not geographical coordinates.

The result:
![image](https://user-images.githubusercontent.com/58122003/100497771-89b40b00-3198-11eb-8400-27f43bcdc2df.png)

Rings provided by the sketch view model:
![image](https://user-images.githubusercontent.com/58122003/100497795-aea87e00-3198-11eb-886e-9e3b06825961.png)

HIstogram
Issue: According to the [documentation](https://developers.arcgis.com/javascript/latest/api-reference/esri-smartMapping-statistics-histogram.html) and the [code example](https://developers.arcgis.com/javascript/latest/sample-code/sandbox/index.html?sample=widgets-histogram), it usually takes three parameters to create a histogram - layer, field, numBins. While all three parameters are set, a warning shown below is created for each data point in sfiHistogramLayer. I am not sure about the reason, but it's probably the reason for getting an empty response in histogram-related queries (histogram(params), summaryStatistics(params)).

Please check the commit content if you need to see code for histogram creation.

The warning for each data point in sfiHistogramLayer:
![image](https://user-images.githubusercontent.com/58122003/100498058-828dfc80-319a-11eb-93e8-b38d91e7c143.png)
