### PR TITLE
Implemented area measurement and histogram for report of SFI

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,8 +185,15 @@
           <div class="statement">
             <span>The average value of the selected area is</span>
             <div id="sfiOutput"></div>
+            <br />
             <span>Histogram of Seaweed Farming Index (SFI)</span>
-            <div id="sfiHistogram">Histogram Here</div>
+            <div id="sfiHistogram">
+              <div id="histogram"></div>
+              <div class="labels">
+                <span style="float: left" id="minSFILabelText"></span>
+                <span style="float: right" id="maxSFILabelText"></span>
+              </div>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
- Created a polygon object with rings provided by the sketch model view
- Got the polygon’s area value using geodesicUtils 
- Displayed the value in the summary report
- Added code for histogram - generating a layer specifically for histogram & creating histogram with queried statistics

Area measurement
Issue: In the [code example](https://developers.arcgis.com/javascript/latest/api-reference/esri-geometry-support-geodesicUtils.html#geodesicAreas), accurate latitude and longitude of each geographical point in a polygon are needed to calculate the area. The rings provided by the sketch view model are not geographical coordinates, which causes a big deviation of the area value. I am not sure what those big numbers mean. I'm pretty sure there's no logical mistake in the implementation itself.

Todo: Figure out why rings provided by the sketch view model are not geographical coordinates.

The result:
![image](https://user-images.githubusercontent.com/58122003/100497771-89b40b00-3198-11eb-8400-27f43bcdc2df.png)

Rings provided by the sketch view model:
![image](https://user-images.githubusercontent.com/58122003/100497795-aea87e00-3198-11eb-886e-9e3b06825961.png)

HIstogram
Histogram created with the default SFI values:
![image](https://user-images.githubusercontent.com/58122003/100499410-698a4900-31a4-11eb-8df2-ea31da8dcdbb.png)

 Histogram created with SFI values calculated by feature 2:
![image](https://user-images.githubusercontent.com/58122003/100499430-8888db00-31a4-11eb-95e6-ff2d8760adad.png)
