### PR TITLE
Fix summary output statement for Report Area section

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@
           <span class="subHead">Report Area</span>
           <hr />
           <div class="statement">
-            <span>The average value of the selected area is</span>
+            <span>The size of the geographic area selected is</span>
             <div id="reportAreaOut">XX km<sup>2</sup></div>
           </div>
         </div>


### PR DESCRIPTION
Minor change for summary output statement for the Report Area section.
<img width="387" alt="Screen Shot 2020-11-28 at 2 05 04 PM" src="https://user-images.githubusercontent.com/41706004/100526957-b8bf8200-3182-11eb-8ce9-366b526ab83a.png">
