### PR TITLE
Fixed the issue of the SFI value difference between the default one a…

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -683,6 +683,7 @@ require([
               let depth = graphic.attributes.Depth;
               if (depth <= maxOCDepth && depth >= minOCDepth)
                 filteredArray.push(graphic);
+              else collectFilteredPoint(graphic);
             });
             return filteredArray;
           }
@@ -692,6 +693,7 @@ require([
             filteringArray.forEach(function (graphic) {
               let distanceToPort = graphic.attributes.Distance_t;
               if (distanceToPort <= maxOcToPort) filteredArray.push(graphic);
+              else collectFilteredPoint(graphic);
             });
             return filteredArray;
           }
@@ -746,6 +748,7 @@ require([
                       });
                     }
                     if (!isIntersected) filteredArray.push(graphic);
+                    else collectFilteredPoint(graphic);
                   });
                   return filteredArray;
                 });
@@ -780,6 +783,7 @@ require([
                       }
                     });
                     if (!isIntersected) filteredArray.push(graphic);
+                    else collectFilteredPoint(graphic);
                   });
                   return filteredArray;
                 });
@@ -818,6 +822,7 @@ require([
                       }
                     });
                     if (!isIntersected) filteredArray.push(graphic);
+                    else collectFilteredPoint(graphic);
                   });
                   return filteredArray;
                 });
@@ -854,6 +859,7 @@ require([
                       }
                     });
                     if (!isIntersected) filteredArray.push(graphic);
+                    else collectFilteredPoint(graphic);
                   });
                   return filteredArray;
                 });
@@ -898,12 +904,26 @@ require([
             });
             resultsLayer.addMany(resultArray);
           }
+
+          function collectFilteredPoint(filteredPoint) {
+            let biomass = filteredPoint.attributes.Maximum_An;
+            let bathymetry = filteredPoint.attributes.Depth;
+
+            filteredPoint.attributes = {
+              Biomass: biomass,
+              Bathymetry: bathymetry,
+              SFI: 0,
+            };
+
+            sfiResultGraphicsArray.push(filteredPoint);
+          }
         });
 
         const clearSFI = document.getElementById("clear-report");
         clearSFI.addEventListener("click", function () {
           view.when(function () {
             resultsLayer.removeAll();
+            isSFICalculationPerformed = false;
           });
         });
       }


### PR DESCRIPTION
…nd the calculated one

- Added filtered points to sfiResultArray with their SFI value set to 0.
- Set isSFICalculationPerformed to false when the clear report button is clicked.

Feature 2 not used:
![image](https://user-images.githubusercontent.com/58122003/100580072-41bff000-3320-11eb-9f02-30d35496d0ab.png)

Feature 2 used:
![image](https://user-images.githubusercontent.com/58122003/100580142-66b46300-3320-11eb-8bda-82de10c5088e.png)

Feature 2 used & the clear report button is clicked:
![image](https://user-images.githubusercontent.com/58122003/100580230-8e0b3000-3320-11eb-9561-1f7a6aa74683.png)
