### PR TITLE
new structure for calculate SFI to solve query limit issue

### DIFF
--- a/js/DataLayers.js
+++ b/js/DataLayers.js
@@ -1,0 +1,42 @@
+class DataLayers {
+    federalAreas = [];
+    stateAreas = [];
+    MPAInventory = [];
+    shippingLanes = [];
+    restrictedZones = [];
+    constructor() {}
+    setFederalAreas(federalAreas) {
+      this.federalAreas = federalAreas;
+    }
+    setStateAreas(stateAreas) {
+      this.stateAreas = stateAreas;
+    }
+    setMPAInventory(MPAInventory) {
+      this.MPAInventory = MPAInventory;
+    }
+    setShippingLanes(shippingLanes) {
+      this.shippingLanes = shippingLanes;
+    }
+    setRestrictedZones(restrictedZones) {
+      this.restrictedZones = restrictedZones;
+    }
+  
+    getFederalAreas() {
+      return this.federalAreas;
+    }
+    getStateAreas() {
+      return this.stateAreas;
+    }
+    getMPAInventory() {
+      return this.MPAInventory;
+    }
+    getShippingLanes() {
+      return this.shippingLanes;
+    }
+    getRestrictedZones() {
+      return this.restrictedZones;
+    }
+  }
+  
+  export { DataLayers };
+  

--- a/js/config.js
+++ b/js/config.js
@@ -5,7 +5,7 @@ const bathymetryLayerUrl =
 const shippingLanesLayerUrl =
   "https://services2.arcgis.com/zzN1kKcv4jyJtkCg/arcgis/rest/services/shippinglanes/FeatureServer/0";
 const dangerZonesAndRestrictedAreasLayerUrl =
-  "https://services2.arcgis.com/zzN1kKcv4jyJtkCg/arcgis/rest/services/DangerZonesAndRestrictedAreas/FeatureServer/0";
+  "https://coast.noaa.gov/arcgis/rest/services/OceanReportingTool/DangerZonesAndRestrictedAreas/MapServer/0";
 const mpaInventoryLayerUrl =
   "https://services2.arcgis.com/zzN1kKcv4jyJtkCg/arcgis/rest/services/ProtectedAreas/FeatureServer/0";
 const principalPortsLayerUrl =


### PR DESCRIPTION
**Key Points**
* Change URL from NOAA hosted to Christina hosted
* A revised code structure to solve the query limit issue
    * the filter data layers will be queried before the actually plotting process
* New POJO `DataLayers` introduced to store all the queried data and being passed through `Promise` layered filter structure


**Success Screen Shot**
* We could successfully filter out the data according to the filter parameters input by users. 
* Note that the timeout error would **NOT** cause any issue
![Screen Shot 2020-11-30 at 11 49 53](https://user-images.githubusercontent.com/28212783/100657033-8177df00-3302-11eb-8433-a31ec9ec6bdf.png)
