### PR TITLE
Message for Mobile Incompatibility

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -7,6 +7,63 @@ body {
   background-color: #162b36;
 }
 
+/* Alert message box for mobile view */
+
+.alert {
+  display: none;
+}
+
+.closebtn {
+  display: none;
+}
+
+@media screen and (max-width: 550px) {
+  .alert {
+    display: block;
+    position: absolute;
+    padding: 20px;
+    background-color: #f44336; /* Red */
+    color: white;
+    margin-top: 200px;
+    margin-bottom: 15px;
+    z-index: 99 !important;
+    font-family: Roboto;
+    font-weight: Regular;
+  }
+
+  .closebtn {
+    display: block;
+    margin-left: 15px;
+    color: white;
+    font-weight: bold;
+    float: right;
+    font-size: 22px;
+    line-height: 20px;
+    cursor: pointer;
+    transition: 0.3s;
+  }
+
+  .closebtn:hover {
+    color: black;
+  }
+}
+
+@media screen and (min-width: 551px){
+  .alert {
+    display: none;
+  }
+
+  .closebtn {
+    display: none;
+  }
+
+  .closebtn:hover {
+    color: black;
+  }
+}
+
+/* Website CSS */
+
 #viewDiv {
   padding: 0;
   margin: 0;
@@ -43,12 +100,6 @@ body {
   font-size: 25px;
   opacity: 1;
   text-align: left;
-}
-
-@media screen and (max-width: 530px) {
-  .title-desktop {
-    display: none;
-  }
 }
 
 a {
@@ -106,7 +157,7 @@ li {
   top: 140px;
   right: 20px;
   position: absolute;
-  z-index: 99;
+  z-index: 98;
   background-color: white;
   border-radius: 8px;
   padding: 10px;
@@ -131,6 +182,11 @@ li {
 }
 
 @media screen and (max-width: 530px) {
+
+  .title-desktop {
+    display: none;
+  }
+
   #sfiCalc {
     height: 50vh;
     width: 35vh;

--- a/index.html
+++ b/index.html
@@ -30,6 +30,13 @@
   </head>
 
   <body>
+    <div class="alert">
+      <span class="closebtn" onclick="this.parentElement.style.display='none';"
+        >&times;</span
+      >
+      This website is not optimized for mobile devices. Please access via
+      desktop browser.
+    </div>
     <div id="nav">
       <div class="nav-logo">
         <a href="https://faculty.sites.uci.edu/davis/" target="_blank">


### PR DESCRIPTION
Show alert message when viewing screen is smaller than 550px in width (standard for a large mobile device)
Message disappears when window is stretched wider than 551px in width (in case user is using desktop browser, just minimized screen size) 
<img width="490" alt="Screen Shot 2020-12-02 at 6 39 54 PM" src="https://user-images.githubusercontent.com/41706004/100957394-3101ac80-34cf-11eb-820e-3d7b9ed7d752.png">
