### PR TITLE
Overrider renderer for Ports and Harbors and layer rename

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
           Operational Constraints
         </div>
         <li>
-          <input type="checkbox" id="principalPortsLayer" /> Principal Ports
+          <input type="checkbox" id="principalPortsLayer" /> Ports and Harbors
         </li>
         <li><input type="checkbox" id="bathymetryLayer" /> Bathymetry</li>
         <div id="checkbox" style="font-weight: bold">

--- a/js/main.js
+++ b/js/main.js
@@ -16,7 +16,7 @@ import {
   mpaInventoryPopupTeamplate,
   principalPortsPopupTemplate,
 } from "./popup_template.js";
-import { referenceScale, kelpProductivityRenderer } from "./renderer.js";
+import { referenceScale, kelpProductivityRenderer, principalPortsRenderer } from "./renderer.js";
 import { DataLayers } from "./DataLayers.js";
 
 require([
@@ -154,6 +154,7 @@ require([
       principalPortsLayer = new FeatureLayer({
         url: principalPortsLayerUrl,
         visible: false,
+        renderer: principalPortsRenderer,
         popupTemplate: principalPortsPopupTemplate,
       });
 
@@ -312,7 +313,7 @@ require([
             },
             {
               layer: principalPortsLayer,
-              title: "Principal Ports",
+              title: "Ports and Harbors",
             },
             {
               layer: federalAndStateWatersLayer,

--- a/js/popup_template.js
+++ b/js/popup_template.js
@@ -1,7 +1,7 @@
 // Popup template for kelp productivity layer
 var kelpProductivityPopupTemplate = {
   // autocasts as new PopupTemplate()
-  title: "Kelp Productivity",
+  title: "Kelp Potential",
   content: [
     {
       type: "fields",
@@ -98,7 +98,7 @@ var mpaInventoryPopupTeamplate = {
 // Popup template for principal ports layer
 var principalPortsPopupTemplate = {
   // autocasts as new PopupTemplate()
-  title: "Principal Ports",
+  title: "Ports and Harbors",
   content: [
     {
       type: "fields",

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -26,7 +26,17 @@ const kelpProductivityRenderer = {
   ],
 };
 
-export {
-  referenceScale,
-  kelpProductivityRenderer,
+const principalPortsRenderer = {
+  type: "simple",
+  symbol: {
+    type: "simple-marker",
+    size: 12,
+    color: "orange",
+    outline: {
+      width: 0.5,
+      color: "white",
+    },
+  },
 };
+
+export { referenceScale, kelpProductivityRenderer, principalPortsRenderer };


### PR DESCRIPTION
* Changed layer name from "Principal Ports" to "Ports and Harbors" 
* Added renderer to override hosted layer render definition to increase point size
<img width="888" alt="Screen Shot 2020-12-03 at 1 57 28 PM" src="https://user-images.githubusercontent.com/41706004/101093369-7d042e00-356f-11eb-83b2-63fae2f165ad.png">
