### PR TITLE
Modify graphic symbol attribute for generated SFI layer

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -954,15 +954,68 @@ require([
                   BiomassRatio: Bn,
                   OperationalConstraint: OC,
                 };
-                graphic.symbol = {
-                  type: "simple-marker", // autocasts as new SimpleMarkerSymbol()
-                  size: 5,
-                  color: "purple",
-                  outline: {
-                    width: 0,
-                    color: "white",
-                  },
-                };
+
+                if (sfi === 0) {
+                  graphic.symbol = {
+                    type: "simple-marker", // autocasts as new SimpleMarkerSymbol()
+                    size: 5,
+                    color: "#FFFFFF",
+                    outline: {
+                      width: 0,
+                      color: "white",
+                    },
+                  };
+                } else if (sfi < 0.2) {
+                  graphic.symbol = {
+                    type: "simple-marker", // autocasts as new SimpleMarkerSymbol()
+                    size: 5,
+                    color: "#E5D1F1",
+                    outline: {
+                      width: 0,
+                      color: "white",
+                    },
+                  };
+                } else if (sfi < 0.4) {
+                  graphic.symbol = {
+                    type: "simple-marker", // autocasts as new SimpleMarkerSymbol()
+                    size: 5,
+                    color: "#CBA3E4",
+                    outline: {
+                      width: 0,
+                      color: "white",
+                    },
+                  };
+                } else if (sfi < 0.6) {
+                  graphic.symbol = {
+                    type: "simple-marker", // autocasts as new SimpleMarkerSymbol()
+                    size: 5,
+                    color: "#B175D6",
+                    outline: {
+                      width: 0,
+                      color: "white",
+                    },
+                  };
+                } else if (sfi < 0.8) {
+                  graphic.symbol = {
+                    type: "simple-marker", // autocasts as new SimpleMarkerSymbol()
+                    size: 5,
+                    color: "#9747C9",
+                    outline: {
+                      width: 0,
+                      color: "white",
+                    },
+                  };
+                } else {
+                  graphic.symbol = {
+                    type: "simple-marker", // autocasts as new SimpleMarkerSymbol()
+                    size: 5,
+                    color: "#7E19BC",
+                    outline: {
+                      width: 0,
+                      color: "white",
+                    },
+                  };
+                }
               });
               resultsLayer.addMany(resultArray);
             }


### PR DESCRIPTION
Changed symbol for the generated SFI layer according to the following color ramp
<img width="836" alt="Screen Shot 2020-12-04 at 5 23 06 PM" src="https://user-images.githubusercontent.com/41706004/101229492-60dabc80-3655-11eb-8a5a-dca42ae4a207.png">

**Result**
<img width="1364" alt="Screen Shot 2020-12-04 at 5 21 14 PM" src="https://user-images.githubusercontent.com/41706004/101229516-75b75000-3655-11eb-98a2-4ab84c7aacff.png">
