### PR TITLE
Edit legend and contour line intervals for bathymetry layer

### DIFF
--- a/js/renderer.js
+++ b/js/renderer.js
@@ -45,104 +45,34 @@ const bathymetryRenderer = {
   field: "depth_m",
   uniqueValueInfos: [
     {
-      value: "-10000",
+      value: "-200",
       description: null,
       symbol: {
         type: "simple-line",
         style: "solid",
-        color: "rgb(187, 0, 255)",
-        width: 3,
-      }
-    },
-    {
-      value: "-9000",
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(160, 0, 252)",
+        color: "rgb(116, 252, 223)",
         width: 1,
-      }
+      },
     },
     {
-      value: "-8000",
+      value: "-300",
       description: null,
       symbol: {
         type: "simple-line",
         style: "solid",
-        color: "rgb(139, 0, 252)",
+        color: "rgb(115, 250, 223)",
+        width: 2,
+      },
+    },
+    {
+      value: "-400",
+      description: null,
+      symbol: {
+        type: "simple-line",
+        style: "solid",
+        color: "rgb(115, 235, 225)",
         width: 1,
-      }
-    },
-    {
-      value: "-7000",
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(112, 0, 250)",
-        width: 1,
-      }
-    },
-    {
-      value: "-6000",
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(82, 0, 247)",
-        width: 1,
-      }
-    },
-    {
-      value: "-5000",
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(49, 0, 247)",
-        width: 3,
-      }
-    },
-    {
-      value: "-4000",
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(21, 17, 245)",
-        width: 1,
-      }
-    },
-    {
-      value: "-3000",
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(58, 58, 242)",
-        width: 1,
-      }
-    },
-    {
-      value: "-2000",
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(82, 96, 242)",
-        width: 1,
-      }
-    },
-    {
-      value: "-1000",
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(95, 130, 237)",
-        width: 1,
-      }
+      },
     },
     {
       value: "-500",
@@ -150,247 +80,167 @@ const bathymetryRenderer = {
       symbol: {
         type: "simple-line",
         style: "solid",
-        color: "rgb(102, 152, 237)",
+        color: "rgb(115, 214, 230)",
         width: 2,
-      }
+      },
     },
     {
-      value: "-200",
+      value: "-600",
       description: null,
       symbol: {
         type: "simple-line",
         style: "solid",
         color: "rgb(110, 198, 230)",
         width: 1,
-      }
+      },
     },
     {
-      value: "-100",
+      value: "-700",
       description: null,
       symbol: {
         type: "simple-line",
         style: "solid",
-        color: "rgb(115, 214, 230)",
+        color: "rgb(102, 152, 237)",
         width: 2,
-      }
+      },
     },
     {
-      value: "-50",
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(115, 235, 225)",
-        width: 1,
-      }
-    },
-    {
-      value: "-20",
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(115, 250, 223)",
-        width: 2,
-      }
-    },
-    {
-      value: "-10",
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(116, 252, 223)",
-        width: 1,
-      }
-    },
-  ],
-}
-
-const bathymetryRenderer1 = {
-  type: "unique-value",
-  field: "RuleID",
-  field2: null,
-  field3: null,
-  fieldDelimiter: ",",
-  uniqueValueInfos: [
-    {
-      value: "6",
-      label: -10000,
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(187, 0, 255)",
-        width: 3,
-      }
-    },
-    {
-      value: "16",
-      label: -9000,
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(160, 0, 252)",
-        width: 1,
-      }
-    },
-    {
-      value: "26",
-      label: -8000,
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(139, 0, 252)",
-        width: 1,
-      }
-    },
-    {
-      value: "36",
-      label: -7000,
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(112, 0, 250)",
-        width: 1,
-      }
-    },
-    {
-      value: "46",
-      label: -6000,
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(82, 0, 247)",
-        width: 1,
-      }
-    },
-    {
-      value: "56",
-      label: -5000,
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(49, 0, 247)",
-        width: 3,
-      }
-    },
-    {
-      value: "66",
-      label: -4000,
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(21, 17, 245)",
-        width: 1,
-      }
-    },
-    {
-      value: "76",
-      label: -3000,
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(58, 58, 242)",
-        width: 1,
-      }
-    },
-    {
-      value: "86",
-      label: -2000,
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(82, 96, 242)",
-        width: 1,
-      }
-    },
-    {
-      value: "96",
-      label: -1000,
+      value: "-800",
       description: null,
       symbol: {
         type: "simple-line",
         style: "solid",
         color: "rgb(95, 130, 237)",
         width: 1,
-      }
+      },
     },
     {
-      value: "101",
-      label: -500,
+      value: "-900",
       description: null,
       symbol: {
         type: "simple-line",
         style: "solid",
-        color: "rgb(102, 152, 237)",
-        width: 2,
-      }
-    },
-    {
-      value: "113",
-      label: -200,
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(110, 198, 230)",
+        color: "rgb(82, 96, 242)",
         width: 1,
-      }
+      },
     },
     {
-      value: "117",
-      label: -100,
+      value: "-1000",
       description: null,
       symbol: {
         type: "simple-line",
         style: "solid",
-        color: "rgb(115, 214, 230)",
-        width: 2,
-      }
-    },
-    {
-      value: "122",
-      label: -50,
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(115, 235, 225)",
+        color: "rgb(58, 58, 242)",
         width: 1,
-      }
+      },
     },
     {
-      value: "125",
-      label: -20,
+      value: "-1100",
       description: null,
       symbol: {
         type: "simple-line",
         style: "solid",
-        color: "rgb(115, 250, 223)",
-        width: 2,
-      }
-    },
-    {
-      value: "126",
-      label: -10,
-      description: null,
-      symbol: {
-        type: "simple-line",
-        style: "solid",
-        color: "rgb(116, 252, 223)",
+        color: "rgb(21, 17, 245)",
         width: 1,
-      }
+      },
+    },
+    {
+      value: "-1200",
+      description: null,
+      symbol: {
+        type: "simple-line",
+        style: "solid",
+        color: "rgb(49, 0, 247)",
+        width: 3,
+      },
+    },
+    {
+      value: "-1300",
+      description: null,
+      symbol: {
+        type: "simple-line",
+        style: "solid",
+        color: "rgb(82, 0, 247)",
+        width: 1,
+      },
+    },
+    {
+      value: "-1400",
+      description: null,
+      symbol: {
+        type: "simple-line",
+        style: "solid",
+        color: "rgb(112, 0, 250)",
+        width: 1,
+      },
+    },
+    {
+      value: "-1500",
+      description: null,
+      symbol: {
+        type: "simple-line",
+        style: "solid",
+        color: "rgb(139, 0, 252)",
+        width: 1,
+      },
+    },
+    {
+      value: "-1600",
+      description: null,
+      symbol: {
+        type: "simple-line",
+        style: "solid",
+        color: "rgb(160, 0, 252)",
+        width: 1,
+      },
+    },
+   
+    {
+      value: "-1700",
+      description: null,
+      symbol: {
+        type: "simple-line",
+        style: "solid",
+        color: "rgb(187, 0, 255)",
+        width: 1,
+      },
+    },
+    {
+      value: "-1800",
+      description: null,
+      symbol: {
+        type: "simple-line",
+        style: "solid",
+        color: "rgb(187, 0, 255)",
+        width: 1,
+      },
+    },
+    {
+      value: "-1900",
+      description: null,
+      symbol: {
+        type: "simple-line",
+        style: "solid",
+        color: "rgb(187, 0, 255)",
+        width: 2,
+      },
+    },
+    {
+      value: "-2000",
+      description: null,
+      symbol: {
+        type: "simple-line",
+        style: "solid",
+        color: "rgb(187, 0, 255)",
+        width: 3,
+      },
     },
   ],
-}
+};
 
-export { referenceScale, kelpProductivityRenderer, principalPortsRenderer, bathymetryRenderer };
+export {
+  referenceScale,
+  kelpProductivityRenderer,
+  principalPortsRenderer,
+  bathymetryRenderer,
+};


### PR DESCRIPTION
* Reversed order for legend -- shallowest --> deepest
* Changed bathymetry contour limit: deepest displayed set to -2000m, increases in -100 meter intervals from -200 m.
<img width="1389" alt="Screen Shot 2020-12-04 at 8 20 44 PM" src="https://user-images.githubusercontent.com/41706004/101233926-1ca8e580-3670-11eb-942e-b20fd98780d4.png">
