### PR TITLE
Show histogram for any SFI value greater than 0 to prevent data skew

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1318,7 +1318,7 @@ require([
           featureLayer.queryFeatures(featureQuery).then(function (response) {
             sfiHistogramArray = response.features.map(function (graphic) {
               let sfi = null;
-              if (sfiFieldName == "SFI") {
+              if (sfiFieldName == "SFI" && graphic.attributes.SFI > 0) {
                 sfi = graphic.attributes.SFI;
               } else if (sfiFieldName == "SFI_defaul") {
                 sfi = graphic.attributes.SFI_defaul;


### PR DESCRIPTION
* Histogram starts at >0 even when area selected covers areas not covered by generated SFI layers
<img width="1519" alt="Screen Shot 2020-12-05 at 4 30 48 PM" src="https://user-images.githubusercontent.com/41706004/101268446-afe92600-3717-11eb-8e2a-7460ebc7a475.png">
