### PR TITLE
popup issue fixed

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -74,10 +74,6 @@ body {
   z-index: 1;
 }
 
-#viewDiv div[style] {
-  top: 15px !important;
-}
-
 #nav {
   height: 50px;
   position: relative;
@@ -107,8 +103,8 @@ a {
 }
 
 .logo {
-  height: 70px;
-  width: 70px;
+  height: 63px;
+  width: 63px;
   padding-left: 5px;
   position: absolute;
 }


### PR DESCRIPTION
This is the solution for the issue [here](https://github.com/macmods/sfi/issues/82)
* The issue is caused by line 77 of `main.css`. 
    * This line of code was supposed to shift down the web window by `15px`.
    * line 77 is not specific enough to target only the web window. As a result, it overrides other elements that we didn't expect.

**Key Changes**
* Remove the down-shift of `viewDiv div[style]` since it is not specific enough and has a big impact
* make the logo slightly smaller to make sure there is no overlapping part between `zoom button` and `navigation bar`

Screen Shot of the current website
![image](https://user-images.githubusercontent.com/28212783/101437588-5f173000-38c5-11eb-97e3-cede8d7c648d.png)


