### PR TITLE
Modify Sea Floor Depth Query Output for Summary Report

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1441,30 +1441,30 @@ require([
       function queryBathymetry() {
         // query for the minimum depth of a selected area
         const minDepth = {
-          onStatisticField: "depth_m",
+          onStatisticField: "Depth",
           outStatisticFieldName: "maxDepth",
           statisticType: "min",
         };
 
         // query for the average depth of a selected area
         const avgDepth = {
-          onStatisticField: "depth_m",
+          onStatisticField: "Depth",
           outStatisticFieldName: "avgDepth",
           statisticType: "avg",
         };
 
         // query for the maximum depth of a selected area
         const maxDepth = {
-          onStatisticField: "depth_m",
+          onStatisticField: "Depth",
           outStatisticFieldName: "minDepth",
           statisticType: "max",
         };
 
-        var query = bathymetryLayer.createQuery();
+        var query = kelpProductivityLayer.createQuery();
         query.geometry = sketchGeometry;
         query.outStatistics = [minDepth, avgDepth, maxDepth];
 
-        bathymetryLayer.queryFeatures(query).then(function (response) {
+        kelpProductivityLayer.queryFeatures(query).then(function (response) {
           var stats = response.features[0].attributes;
 
           const minDepthText = document.getElementById("minDepth");
@@ -1477,10 +1477,9 @@ require([
             "maxDepthAvailable"
           );
 
-          minDepthText.innerHTML = -1 * stats.minDepth;
-          avgDepthText.innerHTML =
-            -1 * Math.round(stats.avgDepth + Number.EPSILON);
-          maxDepthText.innerHTML = -1 * stats.maxDepth;
+          minDepthText.innerHTML = Math.round(stats.minDepth);
+          avgDepthText.innerHTML = Math.round(stats.avgDepth + Number.EPSILON);
+          maxDepthText.innerHTML = Math.round(stats.maxDepth);
           minDepthAvailable.innerHTML = lastValidMinOCDepth + "m";
           maxDepthAvailable.innerHTML = lastValidMaxOCDepth + "m";
         });

--- a/js/main.js
+++ b/js/main.js
@@ -1442,7 +1442,7 @@ require([
         // query for the minimum depth of a selected area
         const minDepth = {
           onStatisticField: "Depth",
-          outStatisticFieldName: "maxDepth",
+          outStatisticFieldName: "minDepth",
           statisticType: "min",
         };
 
@@ -1456,7 +1456,7 @@ require([
         // query for the maximum depth of a selected area
         const maxDepth = {
           onStatisticField: "Depth",
-          outStatisticFieldName: "minDepth",
+          outStatisticFieldName: "maxDepth",
           statisticType: "max",
         };
 


### PR DESCRIPTION
Modified the field that the sea floor depth output is being queried from from bathymetry "depth_m" field to kelp productivity "Depth" field. 
<img width="852" alt="Screen Shot 2020-12-07 at 6 16 44 PM" src="https://user-images.githubusercontent.com/41706004/101429692-63891c00-38b8-11eb-9d06-ff16f5ddcb81.png">
