### PR TITLE
Replace Web Map URL with Permanent Solution

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -241,7 +241,7 @@ require([
     function initiateMapViewer() {
       webmap = new WebMap({
         portalItem: {
-          id: "cdb700c328784388828fb79b9ddbf7dd",
+          id: "5a210e718b6246d59a53b46db6cb1853",
         },
         layers: [
           kelpProductivityLayer,


### PR DESCRIPTION
- Replaced URL for web map to the one published via the UCI ArcGIS Online account. 
- Automatically resolves bookmarks issue. 

<img width="371" alt="Screen Shot 2020-12-08 at 8 36 44 PM" src="https://user-images.githubusercontent.com/41706004/101585671-175fd980-3995-11eb-840c-aa111b755d41.png">
