### PR TITLE
change query base to shippinglanes layer

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -683,14 +683,31 @@ require([
           const querySizeLimit = 5000;
           const maxProductivity = 4;
 
-          getStateAndFederalWaterData()
-            .then(getRestrictedZonesData)
-            .then(getMPAData)
-            .then(getShippingLanesData)
-            .then(calculateSFI);
+          getShippingLanesData()
+          .then(getRestrictedZonesData)
+          .then(getMPAData)
+          .then(getStateAndFederalWaterData)
+          .then(calculateSFI);
 
-          function getStateAndFederalWaterData() {
+          function getShippingLanesData() {
             const dataLayers = new DataLayers();
+            const query = shippingLanesLayer.createQuery();
+            return shippingLanesLayer
+              .queryFeatures(query)
+              .then(function (response) {
+                const shippingLanes = [];
+                response.features.map(function (feature) {
+                  shippingLanes.push(feature);
+                });
+                dataLayers.setShippingLanes(shippingLanes);
+                return dataLayers;
+              });
+          }
+
+          function getStateAndFederalWaterData(dataLayers) {
+            
+            if (!isStateWaterExcluded && isFederalWaterExcluded) return dataLayers;
+
             const query = federalAndStateWatersLayer.createQuery();
             return federalAndStateWatersLayer
               .queryFeatures(query)
@@ -734,21 +751,6 @@ require([
                   MPAInventory.push(feature);
                 });
                 dataLayers.setMPAInventory(MPAInventory);
-                return dataLayers;
-              });
-          }
-
-          function getShippingLanesData(dataLayers) {
-            if (!isShippingLanesExcluded) return dataLayers;
-            const query = shippingLanesLayer.createQuery();
-            return shippingLanesLayer
-              .queryFeatures(query)
-              .then(function (response) {
-                const shippingLanes = [];
-                response.features.map(function (feature) {
-                  shippingLanes.push(feature);
-                });
-                dataLayers.setShippingLanes(shippingLanes);
                 return dataLayers;
               });
           }


### PR DESCRIPTION
**Key Changes** 
* Change query base from `StateAndFederal` layer to `ShippingLanes` layer
    * `StateAndFederal` layer is not stable, and sometimes cannot be queried. We set it as the base query, as a result, it needs to be queried no matter use toggles it on or not
    *  `ShippingLanes` layer is more stable, speaking from experience. 
    * Set `ShippingLanes` layer as the base query, so that if the user doesn’t toggle on state and federal water, such an error won’t happen

